### PR TITLE
fix_runtime_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@
     then set the environment and run the simulation with: 
     
     ```    
-    ./launch.sh {path_to_fat_jar} 
+    ./launch.sh {path_to_fat_jar} {fully_qualified_simulation_name}
     ```
     e.g.:
     
     ```
-    ./launch.sh ./target
+    ./launch.sh ./target uk.gov.hmcts.ccd.simulation.UserProfileSimulation
     ```
     
 ## LICENSE

--- a/launch.sh
+++ b/launch.sh
@@ -2,15 +2,20 @@
 
 if [ -z "$1" ];
 then
-    echo "Simulation launch script"
-    echo
-    echo "Required Parameters : "
-    echo
-    echo " <jar directory path> : directory containing the performance tests jar. Required. Example './launch ./target'"
+    echo "Simulation launch script. Missing required parameter simulation class:"
+    echo " <jar directory path> : directory containing the performance fat-tests.jar. Required. Example './launch ./target'"
     echo
    exit 0;
  fi
 
+ if [ -z "$2" ];
+ then
+     echo "Simulation launch script. Missing required parameter simulation class:"
+     echo " <simulation class> : fully qualified name of the Simulation class. Example 'uk.gov.hmcts.ccd.simulation.UserProfileSimulation'"
+    exit 0;
+  fi
+
+
 COMPILATION_CLASSPATH="$(find -L "$1" -maxdepth 1 -name "*fat-tests.jar" -type f -exec printf :{} ';')"
 JAVA_OPTS="-server -XX:+UseThreadPriorities -XX:ThreadPriorityPolicy=42 -Xms512M -Xmx2048M -XX:+HeapDumpOnOutOfMemoryError -XX:+AggressiveOpts -XX:+OptimizeStringConcat -XX:+UseFastAccessorMethods -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false ${JAVA_OPTS}"
-java $JAVA_OPTS -cp $COMPILATION_CLASSPATH io.gatling.app.Gatling
+java $JAVA_OPTS -cp $COMPILATION_CLASSPATH io.gatling.app.Gatling -s "$2"


### PR DESCRIPTION
Fixed the following runtime error when running fat jar:
'There is no simulation script. Please check that your scripts are in user-files/simulations'

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
